### PR TITLE
option to colorize output

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -10,4 +10,3 @@ nix:
   packages:
   - zlib
   - haskellPackages.hpack
-

--- a/yamlparse-applicative/src/YamlParse/Applicative.hs
+++ b/yamlparse-applicative/src/YamlParse/Applicative.hs
@@ -122,6 +122,7 @@ module YamlParse.Applicative
 
     -- ** Showing the schema to the user
     prettySchema,
+    prettyColorizedSchema,
 
     -- * Interface with 'optparse-applicative'
     confDesc,

--- a/yamlparse-applicative/src/YamlParse/Applicative/IO.hs
+++ b/yamlparse-applicative/src/YamlParse/Applicative/IO.hs
@@ -49,7 +49,7 @@ readFirstConfigFile files = go files
                         fs -> "While parsing files:" : map (("* " <>) . toFilePath) fs
                       referenceMsgs =
                         [ "Reference: ",
-                          T.unpack $ prettySchema $ explainParser (yamlSchema :: YamlParser a)
+                          T.unpack $ prettyColorizedSchema $ explainParser (yamlSchema :: YamlParser a)
                         ]
                   die
                     $ unlines

--- a/yamlparse-applicative/src/YamlParse/Applicative/Pretty.hs
+++ b/yamlparse-applicative/src/YamlParse/Applicative/Pretty.hs
@@ -102,7 +102,7 @@ schemaDoc = go emptyComments
        in \case
             EmptySchema -> e emptyDoc $ addMComment cs $ Just "Nothing to parse"
             AnySchema -> e "<any>" cs
-            ExactSchema t -> e (pretty t <+> annotate Gray "(exact)") cs
+            ExactSchema t -> e (pretty t) cs <+> fromJust (mkCommentsMDoc $ comment "(exact)")
             NullSchema -> e "null" cs
             MaybeSchema s -> go (cs <> comment "or <null>") s
             BoolSchema t -> e "<boolean>" $ addMComment cs t

--- a/yamlparse-applicative/src/YamlParse/Applicative/Pretty.hs
+++ b/yamlparse-applicative/src/YamlParse/Applicative/Pretty.hs
@@ -132,7 +132,7 @@ schemaDoc = go emptyComments
                       indent 2 $ g s
                     ]
             ListSchema s -> g s
-            MapSchema s -> e ("<key>: " <> nest 2 (g s)) cs
+            MapSchema s -> e (annotate White "<key>: " <> nest 2 (g s)) cs
             MapKeysSchema s -> g s
             ApSchema s1 s2 -> align $ vsep [g s1, g s2]
             AltSchema ss ->

--- a/yamlparse-applicative/src/YamlParse/Applicative/Pretty.hs
+++ b/yamlparse-applicative/src/YamlParse/Applicative/Pretty.hs
@@ -19,7 +19,7 @@ import YamlParse.Applicative.Explain
 import YamlParse.Applicative.Parser
 import Data.Text.Prettyprint.Doc.Render.Util.StackMachine
 
-data Color = Yellow | Gray | Red | Blue
+data Color = Yellow | Gray | Red | Blue | White
 
 -- | Render pretty documentation about the 'yamlSchema' of a type
 --
@@ -54,6 +54,7 @@ prettyColorizedSchema = renderSimplyDecorated id startColor resetColor . layoutP
           Gray -> "\x1b[2m"
           Red -> "\x1b[31m"
           Blue -> "\x1b[34m"
+          White -> "\x1b[37m"
         resetColor :: Color -> Text
         resetColor _ = "\x1b[0m"
 
@@ -127,7 +128,7 @@ schemaDoc = go emptyComments
                         Just d -> blueOptional <+> ", default:" <+> pretty d
                     where blueOptional = annotate Blue "optional"
                in vsep
-                    [ keyDoc <> ":" <+> mkComment requiredDoc,
+                    [ annotate White keyDoc <> ":" <+> mkComment requiredDoc,
                       indent 2 $ g s
                     ]
             ListSchema s -> g s


### PR DESCRIPTION
Donezo:

- [x] add helper `prettyColorizedSchema` to colorize the output (gray out lines starting with `#`, yellow for types, e.g. `<string>`, blue/red for optional/optional fields respectively.

No extra dependencies involved.