### PR TITLE
Support aeson-2.0.0.0

### DIFF
--- a/yamlparse-applicative/package.yaml
+++ b/yamlparse-applicative/package.yaml
@@ -1,5 +1,5 @@
 name: yamlparse-applicative
-version: 0.2.0.0
+version: 0.2.0.1
 github: "NorfairKing/yamlparse-applicative"
 license: MIT
 license-file: LICENSE

--- a/yamlparse-applicative/src/YamlParse/Applicative/Class.hs
+++ b/yamlparse-applicative/src/YamlParse/Applicative/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -7,7 +8,9 @@
 module YamlParse.Applicative.Class where
 
 import qualified Data.Aeson as JSON
-import Data.HashMap.Strict (HashMap)
+#if MIN_VERSION_aeson(2,0,0)
+import Data.Aeson.KeyMap (KeyMap)
+#endif
 import Data.Int
 import Data.List.NonEmpty as NE
 import Data.Map (Map)
@@ -151,7 +154,7 @@ instance (Ord k, YamlKeySchema k, YamlSchema v) => YamlSchema (Map k v) where
 -- | There is no instance using YamlKeySchema k yet.
 -- Ideally there wouldn't be one for HashMap Text either because it's insecure,
 -- but the yaml arrives in a HashMap anyway so we might as well expose this.
-instance YamlSchema v => YamlSchema (HashMap Text v) where
+instance YamlSchema v => YamlSchema (KeyMap v) where
   yamlSchema = ParseObject Nothing $ ParseMap yamlSchema
 
 -- | A parser for a required field in an object at a given key

--- a/yamlparse-applicative/src/YamlParse/Applicative/Parser.hs
+++ b/yamlparse-applicative/src/YamlParse/Applicative/Parser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
@@ -9,7 +10,11 @@ import Control.Applicative
 import Control.Monad
 import qualified Data.Aeson as JSON
 import qualified Data.ByteString.Lazy as LB
-import Data.HashMap.Strict (HashMap)
+#if MIN_VERSION_aeson(2,0,0)
+import Data.Aeson.KeyMap (KeyMap)
+#else
+import qualified Data.HashMap.Strict as HM
+#endif
 import Data.Map (Map)
 import Data.Scientific
 import Data.Text (Text)
@@ -19,6 +24,10 @@ import Data.Validity.Text ()
 import Data.Vector (Vector)
 import qualified Data.Yaml as Yaml
 import Text.Read
+
+#if !MIN_VERSION_aeson(2,0,0)
+type KeyMap a = HM.HashMap T.Text a
+#endif
 
 -- | A parser that takes values of type 'i' as input and parses them into values of type 'o'
 --
@@ -77,13 +86,13 @@ data Parser i o where
   -- | Parse a map where the keys are the yaml keys
   ParseMap ::
     Parser Yaml.Value v ->
-    Parser Yaml.Object (HashMap Text v)
+    Parser Yaml.Object (KeyMap v)
   -- | Parse a map's keys via a given parser
   ParseMapKeys ::
     Ord k =>
     Parser Text k ->
-    Parser Yaml.Object (HashMap Text v) ->
-    Parser Yaml.Object (Map k v) -- Once we get out of a HashMap, we'll want to stay out.
+    Parser Yaml.Object (KeyMap v) ->
+    Parser Yaml.Object (Map k v) -- Once we get out of a KeyMap, we'll want to stay out.
 
   -- | Parse a field of an object
   ParseField ::

--- a/yamlparse-applicative/yamlparse-applicative.cabal
+++ b/yamlparse-applicative/yamlparse-applicative.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           yamlparse-applicative
-version:        0.2.0.0
+version:        0.2.0.1
 synopsis:       Declaritive configuration parsing with free docs
 description:    See https://github.com/NorfairKing/yamlparse-applicative
 homepage:       https://github.com/NorfairKing/yamlparse-applicative#readme


### PR DESCRIPTION
Background of the breaking change in aeson-2.0.0.0: https://frasertweedale.github.io/blog-fp/posts/2021-10-12-aeson-hash-flooding-protection.html

Similar change in another repository: https://github.com/snoyberg/yaml/commit/9d32ba1e371f0de82f448410177fbd194d020568